### PR TITLE
feat: Some fixes in generator

### DIFF
--- a/oslo_policy_opa/__init__.py
+++ b/oslo_policy_opa/__init__.py
@@ -26,6 +26,10 @@ from oslo_policy_opa import opts
 LOG = logging.getLogger(__name__)
 
 
+def normalize_name(name: str) -> str:
+    return name.translate(str.maketrans({":": "_", "-": "_", "*": "any"}))
+
+
 class OPACheck(_checks.Check):
     """Check ``opa:`` rules by calling to a remote OpenPolicyAgent server.
 
@@ -47,7 +51,7 @@ class OPACheck(_checks.Check):
                 enforcer.conf.oslo_policy.opa_url,
                 "v1",
                 "data",
-                current_rule.replace(":", "/"),
+                normalize_name(current_rule),
             ]
         )
         json = self._construct_payload(creds, current_rule, enforcer, target)


### PR DESCRIPTION
Attempt to convert policies of more services uncovered certain issues in the generator.
Unfortunately Neutron is again doing what it is famous for - crazy stuff. It
has custome policy checks: OwnerCheck (that dynamically fetches attributes of
the parent/owner resources) and FieldCheck which is extracting certain field or
also fetches network resource. It is not really possible to generate proper
policy for that until a way of acessing such additional information is being
found. There are few ways but the most promising seems to be implementing a
tiny http proxy app that exposes only required attributes of required resources
by looking them in the database directly. This data is very dynamic and cannot
be simply loaded into the OPA as data.
