### PR TITLE
feat: Improve neutron handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -284,6 +284,27 @@ we go again to neutron api? Could we have a closed loop?) or DB. In either way
 it is possible to implement certain caching since OPA http function supports
 that.
 
+This project comes with the override for the Neutron policy enforcement hook
+that allows better efficiency of the policy evaluation. Instead of evaluating
+whether the record can be accessed by the calling user followed by additional
+checks for every attribute of the filtered records a single call can be done to
+the OpenPolicyAgent to filter the record and all fields in one operation. This
+is supported by the `opa_filter` oslo_policy rule. 
+
+.. code-block::
+
+   ..
+   "get_port": "opa_filter:get_port"
+   ..
+
+In order this to work Neutron `/etc/neutron/api-paste.ini` file must be
+modified to use the modified version of the policy enforcement hook:
+
+.. code-block:: ini
+
+  [app:neutronapiapp_v2_0]
+  paste.app_factory = oslo_policy_opa.neutron:APIRouter.factory
+
 Using
 -----
 

--- a/oslo_policy_opa/neutron.py
+++ b/oslo_policy_opa/neutron.py
@@ -1,0 +1,44 @@
+import pecan
+
+from neutron.pecan_wsgi.controllers import root
+from neutron.pecan_wsgi import hooks
+from neutron.pecan_wsgi import startup
+
+from oslo_policy_opa import neutron_policy_hook
+
+
+def v2_factory(global_config, **local_config):
+    # Processing Order:
+    #   As request enters lower priority called before higher.
+    #   Response from controller is passed from higher priority to lower.
+    app_hooks = [
+        hooks.UserFilterHook(),  # priority 90
+        hooks.ContextHook(),  # priority 95
+        hooks.ExceptionTranslationHook(),  # priority 100
+        hooks.BodyValidationHook(),  # priority 120
+        hooks.OwnershipValidationHook(),  # priority 125
+        hooks.QuotaEnforcementHook(),  # priority 130
+        hooks.NotifierHook(),  # priority 135
+        hooks.QueryParametersHook(),  # priority 139
+        neutron_policy_hook.PolicyHook(),  # priority 140
+    ]
+    app = pecan.make_app(
+        root.V2Controller(),
+        debug=False,
+        force_canonical=False,
+        hooks=app_hooks,
+        guess_content_type_from_ext=True,
+    )
+    startup.initialize_all()
+    return app
+
+
+def APIRouter(**local_config):
+    return v2_factory(None, **local_config)
+
+
+def _factory(global_config, **local_config):
+    return v2_factory(global_config, **local_config)
+
+
+setattr(APIRouter, "factory", _factory)

--- a/oslo_policy_opa/neutron_policy_hook.py
+++ b/oslo_policy_opa/neutron_policy_hook.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2015 Mirantis, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_context import context
+from oslo_log import log as logging
+from oslo_policy import policy as oslo_policy
+
+from oslo_policy_opa import opa
+
+from neutron._i18n import _
+from neutron import manager
+from neutron.pecan_wsgi import constants as pecan_constants
+from neutron.pecan_wsgi.hooks import utils
+from neutron.pecan_wsgi.hooks import (
+    policy_enforcement as neutron_policy_enforcement,
+)
+
+from neutron import policy
+
+LOG = logging.getLogger(__name__)
+
+
+def _map_context_attributes_into_creds(context):
+    """oslo.policy method extracting creds from the context"""
+    creds = {}
+    # port public context attributes into the creds dictionary so long as
+    # the attribute isn't callable
+    context_values = context.to_policy_values()
+    for k, v in context_values.items():
+        creds[k] = v
+
+    return creds
+
+
+class PolicyHook(neutron_policy_enforcement.PolicyHook):
+    priority = 140
+
+    def after(self, state):
+        neutron_context = state.request.context.get("neutron_context")
+        resource = state.request.context.get("resource")
+        collection = state.request.context.get("collection")
+        controller = utils.get_controller(state)
+        if not resource:
+            # can't filter a resource we don't recognize
+            return
+        # NOTE(kevinbenton): extension listing isn't controlled by policy
+        if resource == "extension":
+            return
+        try:
+            data = state.response.json
+        except ValueError:
+            return
+        if state.request.method not in pecan_constants.ACTION_MAP:
+            return
+        if not data or (resource not in data and collection not in data):
+            return
+        is_single = resource in data
+        action_type = pecan_constants.ACTION_MAP[state.request.method]
+        if action_type == "get":
+            action = controller.plugin_handlers[controller.SHOW]
+        else:
+            action = controller.plugin_handlers[action_type]
+        key = resource if is_single else collection
+        to_process = [data[resource]] if is_single else data[collection]
+        # in the single case, we enforce which raises on violation
+        # in the plural case, we just check so violating items are hidden
+        policy_method = policy.enforce if is_single else policy.check
+        plugin = manager.NeutronManager.get_plugin_for_resource(collection)
+        try:
+            rule = policy.get_enforcer().rules.get(action)
+            if rule and isinstance(rule, opa.OPAFilter):
+                # The rule explicitly wants to filter/sanitize results. For
+                # this we should rather invoke the OPA directly since oslo.policy
+                # expects checks to return only True/False. And while returnung a dict
+                # works in practice it is not future safe.
+                resp = []
+                if isinstance(neutron_context, context.RequestContext):
+                    creds = _map_context_attributes_into_creds(neutron_context)
+                else:
+                    creds = neutron_context
+                resp = list(rule(to_process, creds, policy.get_enforcer()))
+                if is_single and len(resp) == 0:
+                    raise oslo_policy.PolicyNotAuthorized()
+            else:
+                resp = [
+                    self._get_filtered_item(
+                        state.request, controller, resource, collection, item
+                    )
+                    for item in to_process
+                    if (
+                        state.request.method != "GET"
+                        or policy_method(
+                            neutron_context,
+                            action,
+                            item,
+                            plugin=plugin,
+                            pluralized=collection,
+                        )
+                    )
+                ]
+        except (oslo_policy.PolicyNotAuthorized, oslo_policy.InvalidScope):
+            # This exception must be explicitly caught as the exception
+            # translation hook won't be called if an error occurs in the
+            # 'after' handler.  Instead of raising an HTTPNotFound exception,
+            # we have to set the status_code here to prevent the catch_errors
+            # middleware from turning this into a 500.
+            state.response.status_code = 404
+            return
+
+        if is_single:
+            resp = resp[0]
+        state.response.json = {key: resp}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ oslopolicy-opa-sample-generator = "oslo_policy_opa.generator:generate_sample"
 
 [project.entry-points."oslo.policy.rule_checks"]
 opa = "oslo_policy_opa.opa:OPACheck"
+opa_filter = "oslo_policy_opa.opa:OPAFilter"
 
 [project.optional-dependencies]
 generate = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -2378,7 +2379,6 @@ wheels = [
 
 [[package]]
 name = "oslo-policy-opa"
-version = "0.0.1.dev27"
 source = { editable = "." }
 dependencies = [
     { name = "oslo-log" },
@@ -2417,6 +2417,7 @@ requires-dist = [
     { name = "oslo-policy", specifier = ">=4" },
     { name = "requests", specifier = ">2.30" },
 ]
+provides-extras = ["generate"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8,<9" }]


### PR DESCRIPTION
- add `opa_filter` rule to check `allow` and filter out record attributes in 1 operation
- add neutron policy_enforcement hook (copy and edit from neutron code) to start Neutron with support for the opa_filter rule.
