### PR TITLE
fix: hardcode default remote_timeout on old releases

### DIFF
--- a/oslo_policy_opa/opa.py
+++ b/oslo_policy_opa/opa.py
@@ -46,7 +46,7 @@ class OPACheck(_checks.Check):
             opts._register(enforcer.conf)
             self.opts_registered = True
 
-        timeout = enforcer.conf.oslo_policy.remote_timeout
+        timeout = getattr(enforcer.conf.oslo_policy, "remote_timeout", 1)
 
         url = "/".join(
             [
@@ -148,7 +148,7 @@ class OPAFilter(OPACheck):
             opts._register(enforcer.conf)
             self.opts_registered = True
 
-        timeout = enforcer.conf.oslo_policy.remote_timeout
+        timeout = getattr(enforcer.conf.oslo_policy, "remote_timeout", 1)
 
         results = []
         with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:


### PR DESCRIPTION
Yoga does not have remote_timeout config option in oslo_policy group. If
this is the case default to 1s.
