### PR TITLE
fix: Rename member_id to member for glance

### DIFF
--- a/oslo_policy_opa/generator.py
+++ b/oslo_policy_opa/generator.py
@@ -1326,10 +1326,8 @@ def _generate_opa_policy(namespace, output_dir=None):
                 output.write(f"import data.lib\n\n")
             for opa_policy_rule in opa_policy:
                 import_match = IMPORT_REGEX.match(opa_policy_rule)
-                # print(import_match)
-                # if import_match:
-                #    for m in import_match.groups():
-                #        print(m[3:])
+                if namespace == "glance":
+                    opa_policy_rule = opa_policy_rule.replace("member_id", "member")
                 output.write(opa_policy_rule)
                 output.write("\n")
             if output != sys.stdout:
@@ -1350,6 +1348,8 @@ def _generate_opa_policy(namespace, output_dir=None):
                 )
                 num: int = 1
                 for opa_policy_rule_test in tests:
+                    if namespace == "glance":
+                        opa_policy_rule_test = opa_policy_rule_test.replace("member_id", "member")
                     output.write(opa_policy_rule_test)
                     output.write("\n")
                     num += 1


### PR DESCRIPTION
Glance is using key name transformation when accessing the ImageTarget.
Bypassing oslo.policy causes that target dictionary contains "member"
attribute, while the policy is willing to access "member_id". Since
there is no reasonable easy way of dealing with that on the oslo.policy
plugin side rather rename the attribute in the policy.
While similar renaming is done for "owner" and "id" those does not seem
to be necessary (id is not used anywhere in the policy and owner is
being renamed to the project_id which is already existing in the target
dict).
