### PR TITLE
fix: Address octavia creds context

### DIFF
--- a/oslo_policy_opa/generator.py
+++ b/oslo_policy_opa/generator.py
@@ -58,7 +58,7 @@ ENFORCER_OPTS = [
     cfg.StrOpt(
         "policy-file",
         help="Optional policy.yaml file to use as a source of policy"
-            "customization (full path)",
+        "customization (full path)",
     ),
 ]
 

--- a/oslo_policy_opa/opa.py
+++ b/oslo_policy_opa/opa.py
@@ -114,7 +114,15 @@ class OPACheck(_checks.Check):
                 or element is None
             ):
                 temp_target[key] = {}
-        json = {"input": {"target": temp_target, "credentials": creds}}
+        # NOTE(gtema): Octavia uses `oslo.context:to_policy_values` which
+        # returns `_DeprecatedPolicyValues`, which in turn is
+        # `collections.abc.MutableMapping`. Treat it similarly to the target
+        # object and explicitly access it as a dictionary
+        if not isinstance(creds, dict):
+            temp_creds = {k: copy.deepcopy(creds[k]) for k in creds}
+        else:
+            temp_creds = copy.deepcopy(creds)
+        json = {"input": {"target": temp_target, "credentials": temp_creds}}
         return json
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2408,7 +2408,7 @@ wheels = [
 
 [[package]]
 name = "oslo-policy-opa"
-version = "0.2.1.dev5"
+version = "0.2.1.dev6"
 source = { editable = "." }
 dependencies = [
     { name = "oslo-log" },


### PR DESCRIPTION
Octavia passed
`oslo_context:DeprecatedPolicyValues(collections.abc.MutableMapping)`
object as credentials which logically does not support serialization.
Apply the same logic as for target object.
