### PR TITLE
fix: Do not throw exception when rule not found

### DIFF
--- a/oslo_policy_opa/generator/types.py
+++ b/oslo_policy_opa/generator/types.py
@@ -460,10 +460,12 @@ class RuleCheck(BaseOpaCheck):
                 rules, rule_name
             )
             return test_data
-        raise RuntimeError(
-            f"Cannot generate test data for {self} since the rule is not known"
-        )
+        # Note(gtema): when generating policies for Neutron stadium we do not
+        # have access to rules defined there
         return []
+        # raise RuntimeError(
+        #    f"Cannot generate test data for {self} since the rule is not known"
+        # )
 
 
 class GenericCheck(BaseOpaCheck):


### PR DESCRIPTION
When generating policies for Neutron Stadium project we are not having
rules defined in Neutron, so throwing exception is breaking generation
of policies at all. Disable this for now.
