### PR TITLE
Add possibility to skip threading in opa_filter

### DIFF
--- a/oslo_policy_opa/opts.py
+++ b/oslo_policy_opa/opts.py
@@ -41,7 +41,8 @@ _options = [
         default=4,
         help=_(
             "Maximal count of threads used by the ThreadPoolExecutor to "
-            "parallelize opa_filter based rules."
+            "parallelize opa_filter based rules. Set to `0` to skip threading "
+            "and just process items selially."
         ),
     ),
 ]


### PR DESCRIPTION
We see weird issues in Neutron with opa_filter check pointing to the
direction of threading. Allow skipping threading while still having
effect of filtering item attributes in 1 call to OPA.
