### PR TITLE
feat: Use urllib in opa check directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,29 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+  functional:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Setup OPA
+        uses: open-policy-agent/setup-opa@v2
+        with:
+          version: 1.5.0
+
+      - name: Start OPA
+        run: opa run -s -a localhost:8181 fixtures &
+
+      - name: Run tests
+        run: uv run pytest oslo_policy_opa/tests/functional.py

--- a/fixtures/policy.rego
+++ b/fixtures/policy.rego
@@ -1,0 +1,8 @@
+package test
+
+allow if {
+  input.target.foo == "bar"
+  input.credentials.project_id == "pid"
+}
+
+filtered := input.target

--- a/oslo_policy_opa/tests/functional.py
+++ b/oslo_policy_opa/tests/functional.py
@@ -1,0 +1,62 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import os
+from pathlib import Path
+import pytest
+import tempfile
+
+from oslo_config import cfg
+from oslo_policy import policy
+from oslo_policy import _checks
+from oslo_policy import opts as oslo_opts
+
+from oslo_policy_opa import opa
+from oslo_policy_opa import opts
+
+
+@pytest.fixture
+def config(request):
+    oslo_opts._register(cfg.CONF)
+    opts._register(cfg.CONF)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir, "policy.yaml")
+        if not os.path.exists(tmpdir):
+            os.makedirs(tmpdir)
+
+        cfg.CONF.set_override(
+            "opa_url", "http://localhost:8181", group="oslo_policy"
+        )
+        cfg.CONF.set_override("policy_file", path, group="oslo_policy")
+        yield cfg.CONF
+
+
+def test_invoke_opa(config):
+    enforcer = policy.Enforcer(config, default_rule=_checks.FalseCheck())
+    check = opa.OPACheck("opa", "test")
+
+    assert check({"foo": "bar"}, {"project_id": "pid"}, enforcer, None)
+    assert not check({"foo": "bar1"}, {"project_id": "pid"}, enforcer, None)
+
+
+def test_invoke_opa_filter(config):
+    enforcer = policy.Enforcer(config, default_rule=_checks.FalseCheck())
+    check = opa.OPAFilter("opa", "test")
+
+    assert [{"foo": "bar"}] == list(
+        check(
+            [{"foo": "bar"}, {"foo": "barx"}],
+            {"project_id": "pid"},
+            enforcer,
+            None,
+        )
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ generate = [
 
 [dependency-groups]
 dev = [
-  "pytest>=8,<9", "requests-mock", "fixtures"
+  "pytest>=8,<9", "requests-mock", "fixtures", "pytest-mock"
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -2408,7 +2408,7 @@ wheels = [
 
 [[package]]
 name = "oslo-policy-opa"
-version = "0.2.1.dev11"
+version = "0.2.1.dev24"
 source = { editable = "." }
 dependencies = [
     { name = "oslo-log" },
@@ -2432,6 +2432,7 @@ generate = [
 dev = [
     { name = "fixtures" },
     { name = "pytest" },
+    { name = "pytest-mock" },
     { name = "requests-mock" },
 ]
 
@@ -2454,6 +2455,7 @@ requires-dist = [
 dev = [
     { name = "fixtures" },
     { name = "pytest", specifier = ">=8,<9" },
+    { name = "pytest-mock" },
     { name = "requests-mock" },
 ]
 
@@ -3012,6 +3014,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/28/67172c96ba684058a4d24ffe144d64783d2a270d0af0d9e792737bddc75c/pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e", size = 33241 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/05/77b60e520511c53d1c1ca75f1930c7dd8e971d0c4379b7f4b3f9644685ba/pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0", size = 9923 },
 ]
 
 [[package]]


### PR DESCRIPTION
In production we see sporadic timeouts. Analysis shows that on the
system level OPA responses are received well before the timeout (10ms vs
2sec timeout) but some services (namely Nova and Cinder) still fall with
the timeout. We suspect that there might be something in the eventlet
area or the old version of requests lib that we got stick to. Try to
replace requests usage with the urllib and see whether it helps.
