### PR TITLE
feat: Revert direct use of urllib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ generate = [
 
 [dependency-groups]
 dev = [
-  "pytest>=8,<9", "requests-mock", "fixtures", "pytest-mock"
+  "pytest>=8,<9", "requests-mock", "fixtures"
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -2408,7 +2408,7 @@ wheels = [
 
 [[package]]
 name = "oslo-policy-opa"
-version = "0.2.1.dev24"
+version = "0.2.1.dev26"
 source = { editable = "." }
 dependencies = [
     { name = "oslo-log" },
@@ -2432,7 +2432,6 @@ generate = [
 dev = [
     { name = "fixtures" },
     { name = "pytest" },
-    { name = "pytest-mock" },
     { name = "requests-mock" },
 ]
 
@@ -2455,7 +2454,6 @@ requires-dist = [
 dev = [
     { name = "fixtures" },
     { name = "pytest", specifier = ">=8,<9" },
-    { name = "pytest-mock" },
     { name = "requests-mock" },
 ]
 
@@ -3014,18 +3012,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
-]
-
-[[package]]
-name = "pytest-mock"
-version = "3.14.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/71/28/67172c96ba684058a4d24ffe144d64783d2a270d0af0d9e792737bddc75c/pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e", size = 33241 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/05/77b60e520511c53d1c1ca75f1930c7dd8e971d0c4379b7f4b3f9644685ba/pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0", size = 9923 },
 ]
 
 [[package]]


### PR DESCRIPTION
Unfortunately this does not help. Apparently timeout problems are caused
by the eventlet monkeypatching of the urllib itself. With that in mind
making code more complex does not make any sense. Revert the change
while still keeping some minor code changes.
