### PR TITLE
fix: Properly address the target being sqlalchemy model

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2408,7 +2408,7 @@ wheels = [
 
 [[package]]
 name = "oslo-policy-opa"
-version = "0.2.1.dev26"
+version = "0.2.1.dev27"
 source = { editable = "." }
 dependencies = [
     { name = "oslo-log" },


### PR DESCRIPTION
Manila passes sqlalchemy model as a target into the plugin. Iterating
over it is different since it returns a tuple of key/value.
